### PR TITLE
Add Boards Manager install support

### DIFF
--- a/package_NicoHood_HID_index.json
+++ b/package_NicoHood_HID_index.json
@@ -1,0 +1,45 @@
+{
+  "packages": [
+    {
+      "name": "HID",
+      "maintainer": "NicoHood",
+      "websiteURL": "https://github.com/NicoHood/HID",
+      "email": "",
+      "help": {
+        "online": ""
+      },
+      "platforms": [
+        {
+          "name": "HID Project",
+          "architecture": "avr",
+          "version": "2.2",
+          "category": "HID",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/NicoHood/HID/releases/download/2.2/2.2-boards_manager.zip",
+          "archiveFileName": "2.2-boards_manager.zip",
+          "checksum": "SHA-256:9c86ee28a7ce9fe33e8b07ec643316131e0031b0d22e63bb398902a5fdadbca9",
+          "size": "351303",
+          "boards": [
+            {"name": "Arduino Leonardo"},
+            {"name": "Arduino Micro"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    }
+  ]
+}


### PR DESCRIPTION
As discussed in #35

- Boards Manager install URL for testing: https://raw.githubusercontent.com/per1234/HID/boards-manager-install-test/package_NicoHood_HID_index.json

- You must add the file: https://github.com/per1234/HID/releases/download/2.2/2.2-boards_manager.zip to your release 2.2.

- Your Boards Manager install URL: https://raw.githubusercontent.com/NicoHood/HID/master/package_NicoHood_HID_index.json You may want to add it to the installation section of your wiki and https://github.com/arduino/Arduino/wiki/Unofficial-list-of-3rd-party-boards-support-urls