### PR TITLE
Use OR assignment for NKRO modifier keys

### DIFF
--- a/src/HID-APIs/NKROKeyboardAPI.hpp
+++ b/src/HID-APIs/NKROKeyboardAPI.hpp
@@ -45,7 +45,7 @@ size_t NKROKeyboardAPI::set(KeyboardKeycode k, bool s)
 		// Convert key into bitfield (0 - 7)
 		k = KeyboardKeycode(uint8_t(k) - uint8_t(KEY_LEFT_CTRL));
 		if(s){
-			_keyReport.modifiers = (1 << k);
+			_keyReport.modifiers |= (1 << k);
 		}
 		else{
 			_keyReport.modifiers &= ~(1 << k);


### PR DESCRIPTION
The DefaultKeyboardAPI implementation uses OR assignment instead of basic assignment.