### PR TITLE
Port to SAMD architecture

### DIFF
--- a/src/HID-APIs/SystemAPI.hpp
+++ b/src/HID-APIs/SystemAPI.hpp
@@ -53,7 +53,7 @@ void SystemAPI::releaseAll(void){
 }
 
 void SystemAPI::press(SystemKeycode s){
-#ifdef USBCON
+#if defined(__AVR__) && defined(USBCON)
 	if (s == SYSTEM_WAKE_UP)
 		USBDevice.wakeupHost();
 	else

--- a/src/HID-Settings.h
+++ b/src/HID-Settings.h
@@ -112,3 +112,63 @@ THE SOFTWARE.
 #ifndef HID_REPORTID_SURFACEDIAL
 #define HID_REPORTID_SURFACEDIAL 10
 #endif
+
+#if defined(ARDUINO_ARCH_AVR)
+
+#include "PluggableUSB.h"
+
+#define EPTYPE_DESCRIPTOR_SIZE      uint8_t
+
+#elif defined(ARDUINO_ARCH_SAM)
+
+#include "USB/PluggableUSB.h"
+
+#define EPTYPE_DESCRIPTOR_SIZE      uint32_t
+#define EP_TYPE_INTERRUPT_IN        (UOTGHS_DEVEPTCFG_EPSIZE_512_BYTE | \
+                                    UOTGHS_DEVEPTCFG_EPDIR_IN |         \
+                                    UOTGHS_DEVEPTCFG_EPTYPE_BLK |       \
+                                    UOTGHS_DEVEPTCFG_EPBK_1_BANK |      \
+                                    UOTGHS_DEVEPTCFG_NBTRANS_1_TRANS |  \
+                                    UOTGHS_DEVEPTCFG_ALLOC)
+#define EP_TYPE_INTERRUPT_OUT       (UOTGHS_DEVEPTCFG_EPSIZE_512_BYTE | \
+                                    UOTGHS_DEVEPTCFG_EPTYPE_BLK |       \
+                                    UOTGHS_DEVEPTCFG_EPBK_1_BANK |      \
+                                    UOTGHS_DEVEPTCFG_NBTRANS_1_TRANS |  \
+                                    UOTGHS_DEVEPTCFG_ALLOC)
+#define USB_EP_SIZE                 EPX_SIZE
+#define USB_SendControl             USBD_SendControl
+#define USB_Available               USBD_Available
+#define USB_Recv                    USBD_Recv
+#define USB_Send                    USBD_Send
+#define USB_Flush                   USBD_Flush
+
+#elif defined(ARDUINO_ARCH_SAMD)
+
+#include "USB/PluggableUSB.h"
+
+#define EPTYPE_DESCRIPTOR_SIZE      uint32_t
+#define EP_TYPE_INTERRUPT_IN        USB_ENDPOINT_TYPE_INTERRUPT | USB_ENDPOINT_IN(0);
+#define EP_TYPE_INTERRUPT_OUT       USB_ENDPOINT_TYPE_INTERRUPT | USB_ENDPOINT_OUT(0);
+#define USB_EP_SIZE                 EPX_SIZE
+//#define USB_SendControl           USBDevice.sendControl -> real C++ functions to take care of PGM overloading
+#define USB_Available               USBDevice.available
+#define USB_Recv                    USBDevice.recv
+#define USB_RecvControl             USBDevice.recvControl
+#define USB_Send                    USBDevice.send
+#define USB_Flush                   USBDevice.flush
+
+int USB_SendControl(void* y, uint8_t z);
+int USB_SendControl(uint8_t x, const void* y, uint8_t z);
+
+#define TRANSFER_PGM                0
+#define TRANSFER_RELEASE            0
+
+#define HID_REPORT_TYPE_INPUT       1
+#define HID_REPORT_TYPE_OUTPUT      2
+#define HID_REPORT_TYPE_FEATURE     3
+
+#else
+
+#error "Unsupported architecture"
+
+#endif

--- a/src/MultiReport/AbsoluteMouse.h
+++ b/src/MultiReport/AbsoluteMouse.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/AbsoluteMouseAPI.h"

--- a/src/MultiReport/Consumer.h
+++ b/src/MultiReport/Consumer.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/ConsumerAPI.h"

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/GamepadAPI.h"

--- a/src/MultiReport/ImprovedKeyboard.cpp
+++ b/src/MultiReport/ImprovedKeyboard.cpp
@@ -76,7 +76,9 @@ int Keyboard_::send(void)
 }
 
 void Keyboard_::wakeupHost(void){
+#ifdef __AVR__
 	USBDevice.wakeupHost();
+#endif
 }
 
 Keyboard_ Keyboard;

--- a/src/MultiReport/ImprovedKeyboard.h
+++ b/src/MultiReport/ImprovedKeyboard.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/DefaultKeyboardAPI.h"

--- a/src/MultiReport/ImprovedMouse.h
+++ b/src/MultiReport/ImprovedMouse.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/MouseAPI.h"

--- a/src/MultiReport/NKROKeyboard.h
+++ b/src/MultiReport/NKROKeyboard.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/NKROKeyboardAPI.h"

--- a/src/MultiReport/SurfaceDial.h
+++ b/src/MultiReport/SurfaceDial.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/SurfaceDialAPI.h"

--- a/src/MultiReport/System.h
+++ b/src/MultiReport/System.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/SystemAPI.h"

--- a/src/SingleReport/BootKeyboard.cpp
+++ b/src/SingleReport/BootKeyboard.cpp
@@ -121,12 +121,16 @@ bool BootKeyboard_::setup(USBSetup& setup)
 		}
 		if (request == HID_GET_PROTOCOL) {
 			// TODO improve
+#ifdef __AVR__
 			UEDATX = protocol;
+#endif
 			return true;
 		}
 		if (request == HID_GET_IDLE) {
 			// TODO improve
+#ifdef __AVR__
 			UEDATX = idle;
+#endif
 			return true;
 		}
 	}
@@ -196,7 +200,9 @@ int BootKeyboard_::send(void){
 }
 
 void BootKeyboard_::wakeupHost(void){
+#ifdef __AVR__
 	USBDevice.wakeupHost();
+#endif
 }
 
 

--- a/src/SingleReport/BootKeyboard.h
+++ b/src/SingleReport/BootKeyboard.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/DefaultKeyboardAPI.h"
@@ -72,7 +71,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/BootMouse.h
+++ b/src/SingleReport/BootMouse.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/MouseAPI.h"
@@ -43,7 +42,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/RawHID.h
+++ b/src/SingleReport/RawHID.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 
@@ -164,7 +163,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
 
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
 

--- a/src/SingleReport/SingleAbsoluteMouse.h
+++ b/src/SingleReport/SingleAbsoluteMouse.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/AbsoluteMouseAPI.h"
@@ -44,7 +43,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/SingleConsumer.h
+++ b/src/SingleReport/SingleConsumer.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/ConsumerAPI.h"
@@ -44,7 +43,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/SingleGamepad.h
+++ b/src/SingleReport/SingleGamepad.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/GamepadAPI.h"
@@ -42,7 +41,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/SingleNKROKeyboard.h
+++ b/src/SingleReport/SingleNKROKeyboard.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/NKROKeyboardAPI.h"
@@ -46,7 +45,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/SingleReport/SingleSystem.h
+++ b/src/SingleReport/SingleSystem.h
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #pragma once
 
 #include <Arduino.h>
-#include "PluggableUSB.h"
 #include "HID.h"
 #include "HID-Settings.h"
 #include "../HID-APIs/SystemAPI.h"
@@ -44,7 +43,7 @@ protected:
     int getDescriptor(USBSetup& setup);
     bool setup(USBSetup& setup);
     
-    uint8_t epType[1];
+    EPTYPE_DESCRIPTOR_SIZE epType[1];
     uint8_t protocol;
     uint8_t idle;
     

--- a/src/port/samd.cpp
+++ b/src/port/samd.cpp
@@ -1,0 +1,13 @@
+#include "Arduino.h"
+
+#ifdef ARDUINO_ARCH_SAMD
+
+int USB_SendControl(void* b, unsigned char c) {
+    USBDevice.sendControl(b, c);
+}
+
+int USB_SendControl(uint8_t a, const void* b, uint8_t c) {
+    USBDevice.sendControl(b, c);
+}
+
+#endif


### PR DESCRIPTION
* Make some features AVR only (like USBDevice.wakeupHost() )
* Make some code more generic (mostly EP size and different includes path)

As per mailing list discussion :slightly_smiling_face: 
Tested with MKRVidor4000 ([samd_beta](https://github.com/arduino/ArduinoCore-samd/tree/beta), reliable) and MKRWiFI1010 (samd, unreliable RX) using https://github.com/NicoHood/HID/tree/master/extras/rawhid