### PR TITLE
Alternate fix for #120 bad keyreport issue

### DIFF
--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -63,7 +63,7 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			// if list is not empty
 			if (_keyReport.keycodes[0] != KEY_RESERVED) {
 				uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
-				uint8_t lastIndex;
+				KeyboardKeycode lastElement;
 				for (uint8_t i = 0; i < keycodesSize; i++)
 				{
 					auto key = _keyReport.keycodes[i];
@@ -75,15 +75,15 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 
 					// if the next element is null or if this is the last element
 					if ((i < keycodesSize-1 && _keyReport.keycodes[i+1] == KEY_RESERVED) || i == keycodesSize-1) {
-						lastIndex = i; // set temp key to last filled slot index
+						lastElement = key; // set temp key to last filled slot
+						_keyReport.keycodes[i] = KEY_RESERVED; // clear last filled slot
 						break;
 					}
 				}
 
-				// replace target key with last element, replace last element with null
-				if (keyIndex != 255) {
-					_keyReport.keycodes[keyIndex] = _keyReport.keycodes[lastIndex]; // replace target key
-					_keyReport.keycodes[lastIndex] = KEY_RESERVED;
+				// if target key found
+				if (keyIndex != 255 && k != lastElement) {
+					_keyReport.keycodes[keyIndex] = lastElement; // replace target key
 					return 1;
 				}
 			}

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -60,32 +60,45 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			}
 		} else { // we are removing k from keycodes
 			// this will replace the first instance of k with the last entry in the pseudo-linkedlist
-			// if list is not empty
-			if (_keyReport.keycodes[0] != KEY_RESERVED) {
-				uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
+
+			uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
+
+			// iterate through the keycodes
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+
+				// if target key is found
+				if (key == uint8_t(k)) {
+					// record target key index to keyIndex;
+					keyIndex = i;
+					break;
+				}
+			}
+
+			// if the target key is found (AKA if there is a key to remove)
+			if (keyIndex != 255)
+			{
+				// iterate through the keycodes from the back
 				KeyboardKeycode lastElement;
-				for (uint8_t i = 0; i < keycodesSize; i++)
+				for (uint8_t i = keycodesSize; i > 0; --i)
 				{
-					auto key = _keyReport.keycodes[i];
+					// slot is occupied
+					if (_keyReport.keycodes[i] != KEY_RESERVED)
+					{
+						_keyReport.keycodes[i] = KEY_RESERVED; // remove last element
 
-					if (key == uint8_t(k)) {
-						keyIndex = i;
-						continue;
-					}
-
-					// if the next element is null or if this is the last element
-					if ((i < keycodesSize-1 && _keyReport.keycodes[i+1] == KEY_RESERVED) || i == keycodesSize-1) {
-						lastElement = key; // set temp key to last filled slot
-						_keyReport.keycodes[i] = KEY_RESERVED; // clear last filled slot
+						// target key is the last non-null element in the pseudo-linkedlist
+						if (i == keyIndex)
+						{
+							return 1; // no further operations needed, exit now
+						}
+						lastElement = _keyReport.keycodes[i]; // copy current element to temp
 						break;
 					}
 				}
-
-				// if target key found
-				if (keyIndex != 255 && k != lastElement) {
-					_keyReport.keycodes[keyIndex] = lastElement; // replace target key
-					return 1;
-				}
+				_keyReport.keycodes[keyIndex] = lastElement; // replace k with last element
+				return 1;
 			}
 		}
 	}

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -42,27 +42,11 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 	}
 	// Its a normal key
 	else{
-		// my code starts
-
 		// get size of keycodes during compile time
 		const uint8_t keycodesSize = sizeof(_keyReport.keycodes);
 
-
-		// if we are removing keys
-		if (!s) {
-			// iterate through the keycodes
-			for (uint8_t i = 0; i < keycodesSize; i++)
-			{
-				auto key = _keyReport.keycodes[i];
-				// if target key is found
-				if (key == k) {
-					// remove target and exit
-					_keyReport.keycodes[i] = KEY_RESERVED;
-					return 1;
-				}
-			}
-		} // if we are adding an element to keycodes
-		else {
+		// if we are adding an element to keycodes
+		if (s){
 			// iterate through the keycodes
 			for (uint8_t i = 0; i < keycodesSize; i++)
 			{
@@ -85,11 +69,19 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 					return 1;
 				}
 			}
+		} else { // we are removing k from keycodes
+			// iterate through the keycodes
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+				// if target key is found
+				if (key == k) {
+					// remove target and exit
+					_keyReport.keycodes[i] = KEY_RESERVED;
+					return 1;
+				}
+			}
 		}
-
-
-
-		// my code ends
 	}
 
 	// No empty/pressed key was found

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #pragma once
 
 
-size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s) 
+size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 {
 	// It's a modifier key
 	if(k >= KEY_LEFT_CTRL && k <= KEY_RIGHT_GUI)
@@ -42,26 +42,56 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 	}
 	// Its a normal key
 	else{
-		// Add k to the key report only if it's not already present
-		// and if there is an empty slot. Remove the first available key.
-		for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++)
-		{
-			auto key = _keyReport.keycodes[i];
-			
-			// Is key already in the list or did we found an empty slot?
-			if (s && (key == uint8_t(k) || key == KEY_RESERVED)) {
-				_keyReport.keycodes[i] = k;
-				return 1;
+		// my code starts
+
+		// get size of keycodes during compile time
+		const uint8_t keycodesSize = sizeof(_keyReport.keycodes);
+
+
+		// if we are removing keys
+		if (!s) {
+			// iterate through the keycodes
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+				// if target key is found
+				if (key == k) {
+					// remove target and exit
+					_keyReport.keycodes[i] = KEY_RESERVED;
+					return 1;
+				}
 			}
-			
-			// Test the key report to see if k is present. Clear it if it exists.
-			if (!s && (key == k)) {
-				_keyReport.keycodes[i] = KEY_RESERVED;
-				return 1;
+		} // if we are adding an element to keycodes
+		else {
+			// iterate through the keycodes
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+				// if target key is found
+				if (key == uint8_t(k)) {
+					// do nothing and exit
+					return 1;
+				}
+			}
+			// iterate through the keycodes again, this only happens if no existing
+			// keycodes matches k
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+				// if first instance of empty slot is found
+				if (key == KEY_RESERVED) {
+					// change empty slot to k and exit
+					_keyReport.keycodes[i] = k;
+					return 1;
+				}
 			}
 		}
+
+
+
+		// my code ends
 	}
-	
+
 	// No empty/pressed key was found
 	return 0;
 }
@@ -104,7 +134,7 @@ size_t DefaultKeyboardAPI::press(ConsumerKeycode k)
 }
 
 
-size_t DefaultKeyboardAPI::release(ConsumerKeycode k) 
+size_t DefaultKeyboardAPI::release(ConsumerKeycode k)
 {
 	// Release key and send report to host
 	auto ret = remove(k);
@@ -115,14 +145,14 @@ size_t DefaultKeyboardAPI::release(ConsumerKeycode k)
 }
 
 
-size_t DefaultKeyboardAPI::add(ConsumerKeycode k) 
+size_t DefaultKeyboardAPI::add(ConsumerKeycode k)
 {
 	// No 2 byte keys are supported
 	if(k > 0xFF){
 		setWriteError();
 		return 0;
 	}
-	
+
 	// Place the key inside the reserved keyreport position.
 	// This does not work on Windows.
 	_keyReport.reserved = k;
@@ -130,13 +160,13 @@ size_t DefaultKeyboardAPI::add(ConsumerKeycode k)
 }
 
 
-size_t DefaultKeyboardAPI::remove(ConsumerKeycode k) 
+size_t DefaultKeyboardAPI::remove(ConsumerKeycode k)
 {
 	// No 2 byte keys are supported
 	if(k > 0xFF){
 		return 0;
 	}
-	
+
 	// Always release the key, to make it simpler releasing a consumer key
 	// without releasing all other normal keyboard keys.
 	_keyReport.reserved = HID_CONSUMER_UNASSIGNED;

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -51,57 +51,39 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			for (uint8_t i = 0; i < keycodesSize; i++)
 			{
 				auto key = _keyReport.keycodes[i];
-
-				// write to keycodes on first instance of k or null in keycodes
-				if (key == uint8_t(k) || key == KEY_RESERVED) {
+				// if target key is found
+				if (key == uint8_t(k)) {
+					// do nothing and exit
+					return 1;
+				}
+			}
+			// iterate through the keycodes again, this only happens if no existing
+			// keycodes matches k
+			for (uint8_t i = 0; i < keycodesSize; i++)
+			{
+				auto key = _keyReport.keycodes[i];
+				// if first instance of empty slot is found
+				if (key == KEY_RESERVED) {
+					// change empty slot to k and exit
 					_keyReport.keycodes[i] = k;
 					return 1;
 				}
 			}
 		} else { // we are removing k from keycodes
-			// this will replace the first instance of k with the last entry in the pseudo-linkedlist
-
-			uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
-
 			// iterate through the keycodes
 			for (uint8_t i = 0; i < keycodesSize; i++)
 			{
 				auto key = _keyReport.keycodes[i];
-
 				// if target key is found
-				if (key == uint8_t(k)) {
-					// record target key index to keyIndex;
-					keyIndex = i;
-					break;
+				if (key == k) {
+					// remove target and exit
+					_keyReport.keycodes[i] = KEY_RESERVED;
+					return 1;
 				}
-			}
-
-			// if the target key is found (AKA if there is a key to remove)
-			if (keyIndex != 255)
-			{
-				// iterate through the keycodes from the back
-				KeyboardKeycode lastElement;
-				for (uint8_t i = keycodesSize; i > 0; --i)
-				{
-					// slot is occupied
-					if (_keyReport.keycodes[i] != KEY_RESERVED)
-					{
-						_keyReport.keycodes[i] = KEY_RESERVED; // remove last element
-
-						// target key is the last non-null element in the pseudo-linkedlist
-						if (i == keyIndex)
-						{
-							return 1; // no further operations needed, exit now
-						}
-						lastElement = _keyReport.keycodes[i]; // copy current element to temp
-						break;
-					}
-				}
-				_keyReport.keycodes[keyIndex] = lastElement; // replace k with last element
-				return 1;
 			}
 		}
 	}
+
 	// No empty/pressed key was found
 	return 0;
 }

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -51,39 +51,57 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			for (uint8_t i = 0; i < keycodesSize; i++)
 			{
 				auto key = _keyReport.keycodes[i];
-				// if target key is found
-				if (key == uint8_t(k)) {
-					// do nothing and exit
-					return 1;
-				}
-			}
-			// iterate through the keycodes again, this only happens if no existing
-			// keycodes matches k
-			for (uint8_t i = 0; i < keycodesSize; i++)
-			{
-				auto key = _keyReport.keycodes[i];
-				// if first instance of empty slot is found
-				if (key == KEY_RESERVED) {
-					// change empty slot to k and exit
+
+				// write to keycodes on first instance of k or null in keycodes
+				if (key == uint8_t(k) || key == KEY_RESERVED) {
 					_keyReport.keycodes[i] = k;
 					return 1;
 				}
 			}
 		} else { // we are removing k from keycodes
+			// this will replace the first instance of k with the last entry in the pseudo-linkedlist
+
+			uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
+
 			// iterate through the keycodes
 			for (uint8_t i = 0; i < keycodesSize; i++)
 			{
 				auto key = _keyReport.keycodes[i];
+
 				// if target key is found
-				if (key == k) {
-					// remove target and exit
-					_keyReport.keycodes[i] = KEY_RESERVED;
-					return 1;
+				if (key == uint8_t(k)) {
+					// record target key index to keyIndex;
+					keyIndex = i;
+					break;
 				}
+			}
+
+			// if the target key is found (AKA if there is a key to remove)
+			if (keyIndex != 255)
+			{
+				// iterate through the keycodes from the back
+				KeyboardKeycode lastElement;
+				for (uint8_t i = keycodesSize; i > 0; --i)
+				{
+					// slot is occupied
+					if (_keyReport.keycodes[i] != KEY_RESERVED)
+					{
+						_keyReport.keycodes[i] = KEY_RESERVED; // remove last element
+
+						// target key is the last non-null element in the pseudo-linkedlist
+						if (i == keyIndex)
+						{
+							return 1; // no further operations needed, exit now
+						}
+						lastElement = _keyReport.keycodes[i]; // copy current element to temp
+						break;
+					}
+				}
+				_keyReport.keycodes[keyIndex] = lastElement; // replace k with last element
+				return 1;
 			}
 		}
 	}
-
 	// No empty/pressed key was found
 	return 0;
 }

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -63,7 +63,7 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			// if list is not empty
 			if (_keyReport.keycodes[0] != KEY_RESERVED) {
 				uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
-				KeyboardKeycode lastElement;
+				uint8_t lastIndex;
 				for (uint8_t i = 0; i < keycodesSize; i++)
 				{
 					auto key = _keyReport.keycodes[i];
@@ -75,15 +75,15 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 
 					// if the next element is null or if this is the last element
 					if ((i < keycodesSize-1 && _keyReport.keycodes[i+1] == KEY_RESERVED) || i == keycodesSize-1) {
-						lastElement = key; // set temp key to last filled slot
-						_keyReport.keycodes[i] = KEY_RESERVED; // clear last filled slot
+						lastIndex = i; // set temp key to last filled slot index
 						break;
 					}
 				}
 
-				// if target key found
-				if (keyIndex != 255 && k != lastElement) {
-					_keyReport.keycodes[keyIndex] = lastElement; // replace target key
+				// replace target key with last element, replace last element with null
+				if (keyIndex != 255) {
+					_keyReport.keycodes[keyIndex] = _keyReport.keycodes[lastIndex]; // replace target key
+					_keyReport.keycodes[lastIndex] = KEY_RESERVED;
 					return 1;
 				}
 			}

--- a/src/HID-APIs/DefaultKeyboardAPI.hpp
+++ b/src/HID-APIs/DefaultKeyboardAPI.hpp
@@ -60,45 +60,32 @@ size_t DefaultKeyboardAPI::set(KeyboardKeycode k, bool s)
 			}
 		} else { // we are removing k from keycodes
 			// this will replace the first instance of k with the last entry in the pseudo-linkedlist
-
-			uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
-
-			// iterate through the keycodes
-			for (uint8_t i = 0; i < keycodesSize; i++)
-			{
-				auto key = _keyReport.keycodes[i];
-
-				// if target key is found
-				if (key == uint8_t(k)) {
-					// record target key index to keyIndex;
-					keyIndex = i;
-					break;
-				}
-			}
-
-			// if the target key is found (AKA if there is a key to remove)
-			if (keyIndex != 255)
-			{
-				// iterate through the keycodes from the back
+			// if list is not empty
+			if (_keyReport.keycodes[0] != KEY_RESERVED) {
+				uint8_t keyIndex = 255; // if keyIndex == 255 then k does not exist in keycodes
 				KeyboardKeycode lastElement;
-				for (uint8_t i = keycodesSize; i > 0; --i)
+				for (uint8_t i = 0; i < keycodesSize; i++)
 				{
-					// slot is occupied
-					if (_keyReport.keycodes[i] != KEY_RESERVED)
-					{
-						_keyReport.keycodes[i] = KEY_RESERVED; // remove last element
+					auto key = _keyReport.keycodes[i];
 
-						// target key is the last non-null element in the pseudo-linkedlist
-						if (i == keyIndex)
-						{
-							return 1; // no further operations needed, exit now
-						}
-						lastElement = _keyReport.keycodes[i]; // copy current element to temp
+					if (key == uint8_t(k)) {
+						keyIndex = i;
+						continue;
+					}
+
+					// if the next element is null or if this is the last element
+					if ((i < keycodesSize-1 && _keyReport.keycodes[i+1] == KEY_RESERVED) || i == keycodesSize-1) {
+						lastElement = key; // set temp key to last filled slot
+						_keyReport.keycodes[i] = KEY_RESERVED; // clear last filled slot
 						break;
 					}
 				}
-				_keyReport.keycodes[keyIndex] = lastElement; // replace k with last element
-				return 1;
+
+				// if target key found
+				if (keyIndex != 255 && k != lastElement) {
+					_keyReport.keycodes[keyIndex] = lastElement; // replace target key
+					return 1;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi, I want to get #146 moving as soon as possible so I I'd like to see if this version of the fix would be more acceptable to you. The code looks dumbed down because it has several for loops instead of a single loop, but this seems to be the best way IMO to properly separate the tasks involved.

You cited readability concerns over #121 so my solution has no pointers and should be somewhat faster than Steve's other solution even though I can't prove it.

Please allow me to part my post into 3 sections

* Code structure
* Speed test (Steve pointer code, original code, my code)
* Validity test

_______________

**Code Structure**

The original issue is caused by the following bit of code

```
		for (uint8_t i = 0; i < sizeof(_keyReport.keycodes); i++)
		{
			auto key = _keyReport.keycodes[i];
			
			// Is key already in the list or did we found an empty slot?
			if (s && (key == uint8_t(k) || key == KEY_RESERVED)) {
				_keyReport.keycodes[i] = k;
				return 1; <============== OVER HERE
			}
			
			// Test the key report to see if k is present. Clear it if it exists.
			if (!s && (key == k)) {
				_keyReport.keycodes[i] = KEY_RESERVED;
				return 1;
			}
}
```
The original code creates a duplicate of `k` into `keycodes` if it iterates to an empty slot before reaching a slot with `k` because it exits once it finds a blank slot or a slot with `k`

My code iterates through `keycodes` looking for an existing `k` first, if `k` is found, then it exits right away and does nothing as intended. If no `k` was found, then it iterates through the array until an empty slot is found then inputs `k` into the empty slot.

My code has several implications in terms of speed, there are 1 or 2 for loops depending on whether you are adding or removing from the array, if you are removing, then it should be as fast as before. If you are adding, then you are at at most O(2n) which is the same as O(n). Also, if you are adding to `keycodes` and it already exists, then it should also be as fast as the original because the loop would stop at the first instance of `k`.

________

**On Speed in The Real World**

Steve kindly provided a test case in #121 but I can't run it independently because I don't have a PS2 keyboard on hand and my soldering irons are at work not at home. I made my own tests running on a pro micro, below are the two simple tests that I've ran.

* [test 1 stairs output](https://gist.github.com/blahlicus/afc8a77e38867c249eb240e26633fd5c#file-speedtesterstairs-ino)
* [test 2 trapezoid output](https://gist.github.com/blahlicus/afc8a77e38867c249eb240e26633fd5c#file-speedtestertrapezoid-ino)

I ran the trapezoid test on my own solution, #121, and the original code. I did not run the stairs test with the original code because I fear it might bug it.

Surprisingly, All three versions returned the same results for both tests as follows:

* 1 key down then up: 2000ms
* 2 key down then up: 4000ms
* 3 key down then up: 6000ms
* 4 key down then up: 8000ms
* 5 key down then up: 10000ms
* 6 key down then up: 12000ms

It is possible that my test is flawed but it seems like there are other overheads involved with HID such that it always takes 2ms per scancode to go through, so my solution does not seem to be slower than a solution utilising pointers.


______________

**Validity Test**

To make sure my code works, I ran [this test](https://gist.github.com/blahlicus/c5877fb9da66c7171b4250ab6cee127a#file-keyreporttest-ino) to make sure `key2` in #120 is properly releasing. I tested the original code, Steve's code, and my own. the original code is indeed bugged, and both Steve's and my code solves the problem.

EDIT: spelling