### PR TITLE
Fix erroneous check not to exceed the size of asciimap

### DIFF
--- a/src/HID-APIs/KeyboardAPI.hpp
+++ b/src/HID-APIs/KeyboardAPI.hpp
@@ -148,7 +148,7 @@ size_t KeyboardAPI::remove(uint8_t k)
 
 size_t KeyboardAPI::set(uint8_t k, bool s){
 	// Ignore invalid input
-	if(k >= sizeof(_asciimap)){
+	if(k >= sizeof(_asciimap)/sizeof(_asciimap[0])){
 		setWriteError();
 		return 0;
 	}


### PR DESCRIPTION
Fix the following compile error:
```
/home/.../HID-Project/src/MultiReport/../HID-APIs/KeyboardAPI.hpp: In member function 'size_t KeyboardAPI::set(uint8_t, bool)':
/home/.../HID-Project/src/MultiReport/../HID-APIs/KeyboardAPI.hpp:151:7: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  if(k >= sizeof(_asciimap)){
     ~~^~~~~~~~~~
```

This is required because _asciimap is an array of uint16_t, while the check was treating it as an array of uint8_t.