### PR TITLE
fix compatibility issues with default keyboard

### DIFF
--- a/src/HID-Project.h
+++ b/src/HID-Project.h
@@ -48,10 +48,13 @@ THE SOFTWARE.
 #include "MultiReport/System.h"
 #include "SingleReport/RawHID.h"
 #ifndef KEYBOARD_h
-#include "SingleReport/BootKeyboard.h"
-#include "MultiReport/ImprovedKeyboard.h"
-#include "SingleReport/SingleNKROKeyboard.h"
-#include "MultiReport/NKROKeyboard.h"
+  #pragma message "Using improved keyboard modules"
+  #include "SingleReport/BootKeyboard.h"
+  #include "MultiReport/ImprovedKeyboard.h"
+  #include "SingleReport/SingleNKROKeyboard.h"
+  #include "MultiReport/NKROKeyboard.h"
+#else
+  #pragma message "Using classic keyboard module"
 #endif
 #include "MultiReport/SurfaceDial.h"
 

--- a/src/HID-Project.h
+++ b/src/HID-Project.h
@@ -48,13 +48,13 @@ THE SOFTWARE.
 #include "MultiReport/System.h"
 #include "SingleReport/RawHID.h"
 #ifndef KEYBOARD_h
-  #pragma message "Using improved keyboard modules"
+  #pragma message "Using improved HID-Project keyboard modules"
   #include "SingleReport/BootKeyboard.h"
   #include "MultiReport/ImprovedKeyboard.h"
   #include "SingleReport/SingleNKROKeyboard.h"
   #include "MultiReport/NKROKeyboard.h"
 #else
-  #pragma message "Using classic keyboard module"
+  #pragma message "Using classic Arduino keyboard module"
 #endif
 #include "MultiReport/SurfaceDial.h"
 

--- a/src/HID-Project.h
+++ b/src/HID-Project.h
@@ -47,10 +47,12 @@ THE SOFTWARE.
 #include "SingleReport/SingleSystem.h"
 #include "MultiReport/System.h"
 #include "SingleReport/RawHID.h"
+#ifndef KEYBOARD_h
 #include "SingleReport/BootKeyboard.h"
 #include "MultiReport/ImprovedKeyboard.h"
 #include "SingleReport/SingleNKROKeyboard.h"
 #include "MultiReport/NKROKeyboard.h"
+#endif
 #include "MultiReport/SurfaceDial.h"
 
 // Include Teensy HID afterwards to overwrite key definitions if used


### PR DESCRIPTION
A temporary solution to the compatibility problem between windows and your fancy keyboards. By checking if the default keyboard library was imported beforehand you can get back the "Keyboard.write(KEY_F13)" without loosing "System.write(SYSTEM_SLEEP)"
See "issue" #267 and the fact that importing both libraries (Keyboard.h and HID-Project.h) causes the keys to be redefined and crashes the compiler