### PR TITLE
Multi-touch touchscreen support (#123)

### DIFF
--- a/examples/MultiTouch/MultiTouch.ino
+++ b/examples/MultiTouch/MultiTouch.ino
@@ -1,0 +1,39 @@
+/*
+  Copyright (c) 2021 ilufang
+  See the readme for credit to other people.
+
+  Multi-touch touchscreen example
+  Draw 7 parallel lines across the screen.
+  Open Microsoft Whiteboard, select a brush and press the button.
+
+  See HID Project documentation for more infos
+  https://github.com/NicoHood/HID/wiki/Gamepad-API
+*/
+
+#include <HID-Project.h>
+
+const int pinButton = 2;
+
+void setup() {
+	pinMode(pinButton, INPUT_PULLUP);
+	MultiTouch.begin();
+}
+
+void loop() {
+	while(digitalRead(pinButton));
+
+	int16_t x = 2000, y = 2000;
+
+	for (; x <= 8000; x+=10) {
+		for (int i = 0; i < 7; i++) {
+			MultiTouch.setFinger(i, x, y+i*1000, (i+1)*15);
+		}
+		MultiTouch.send();
+		delay(10);
+	}
+
+	for (int i = 0; i < 7; i++) {
+		MultiTouch.releaseFinger(i);
+	}
+	MultiTouch.send();
+}

--- a/src/HID-APIs/MultiTouchAPI.h
+++ b/src/HID-APIs/MultiTouchAPI.h
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2021 ilufang
+See the readme for credit to other people.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Include guard
+#pragma once
+
+/// Maximum amount of fingers supported
+#define HID_MULTITOUCH_MAXFINGERS 10
+/// Number of fingers in a single report
+#define HID_MULTITOUCH_REPORTFINGERS 2
+
+// A report will always be the same size, even if you report fewer fingers than
+// REPORTFINGERS. The unused finger entries will simply be zero. If more fingers
+// are present than REPORTFINGERS, multiple reports will be sent to report all
+// fingers. This is know as "Hybrid Mode" on MSDN. The number of supported
+// fingers identified by Windows will still be MAXFINGERS. More than MAXFINGERS
+// contacts may be ignored by Windows even with hybrid mode.
+
+#define _MT_STATE_INACTIVE 0
+#define _MT_STATE_CONTACT  1
+#define _MT_STATE_RELEASED 2
+
+typedef struct ATTRIBUTE_PACKED {
+	uint8_t reportID;
+	uint8_t count;
+	struct ATTRIBUTE_PACKED {
+		uint8_t identifier;
+		uint8_t touch;
+		uint8_t pressure;
+		uint8_t x1, x0;
+		uint8_t y1, y0;
+	} contacts[HID_MULTITOUCH_REPORTFINGERS];
+} HID_MultiTouchReport_Data_t;
+
+typedef struct {
+	uint8_t status;
+	int8_t pressure;
+	int16_t x, y;
+} _finger_t;
+
+class MultiTouchAPI
+{
+public:
+	MultiTouchAPI() {
+		_fingers_count = 0;
+		for (int i = 0; i < HID_MULTITOUCH_MAXFINGERS; i++) {
+			_fingers[i].status = _MT_STATE_INACTIVE;
+		}
+	}
+
+	inline void begin();
+
+	/**
+	 * Set contact status for a finger in the internal data structure. You must
+	 * call send manually after setting all fingers to flush them through USB.
+	 *
+	 * @param id Finger id. Must be in the range of 0-MAXFINGERS. Same finger
+	 *           must have same id throughout contact. Allocations does not need
+	 *           to be continuous.
+	 * @param x, y Coordinates. Range 0-10000. (0,0) is top-left on Windows.
+	 * @param pressure Contact pressure. Range 0-127. When set to 0, the touch
+	 *                 is reported as hovering (in-range)
+	 * @return 1 if success. 0 if id is out-of-bounds
+	 */
+	inline int setFinger(uint8_t id, int16_t x, int16_t y, int8_t pressure=100);
+
+	/**
+	 * Release finger in the internal data structure. You must call send
+	 * manually after setting all fingers to flush them through USB.
+	 *
+	 * @param id Finger id. Must be in the range of 0-MAXFINGERS. Same finger
+	 *           must have same id throughout contact. Allocations does not need
+	 *           to be continuous.
+	 * @return 1 if success. 0 if id is out-of-bounds
+	 */
+	inline int releaseFinger(uint8_t id);
+
+	/**
+	 * Generates an HID report reflecting the currently recorded touch status
+	 * and send through USB.
+	 */
+	inline int send();
+
+protected:
+	/// Send the generated report. Needs to be implemented in a lower level
+	virtual int _sendReport() = 0;
+
+	/// Internal records of the current touch status
+	_finger_t _fingers[HID_MULTITOUCH_MAXFINGERS];
+	/// Number of active contacts, including just release contacts
+	uint8_t _fingers_count;
+
+	/// HID report to send. Not
+	HID_MultiTouchReport_Data_t _report;
+};
+
+// Implementation is inline
+#include "MultiTouchAPI.hpp"

--- a/src/HID-APIs/MultiTouchAPI.hpp
+++ b/src/HID-APIs/MultiTouchAPI.hpp
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2021 ilufang
+See the readme for credit to other people.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Include guard
+#pragma once
+
+#define _LSB(v) ((v >> 8) & 0xff)
+#define _MSB(v) (v & 0xff)
+
+void MultiTouchAPI::begin() {
+	send();
+}
+
+int MultiTouchAPI::setFinger(uint8_t id, int16_t x, int16_t y, int8_t pressure) {
+	if (id >= HID_MULTITOUCH_MAXFINGERS) {
+		return 0;
+	}
+	if (_fingers[id].status == _MT_STATE_INACTIVE) {
+		_fingers_count++;
+	}
+	_fingers[id].status = _MT_STATE_CONTACT;
+	_fingers[id].pressure = pressure;
+	_fingers[id].x = x;
+	_fingers[id].y = y;
+	return 1;
+}
+
+int MultiTouchAPI::releaseFinger(uint8_t id) {
+	if (id >= HID_MULTITOUCH_MAXFINGERS) {
+		return 0;
+	}
+	_fingers[id].status = _MT_STATE_RELEASED;
+	return 1;
+}
+
+int MultiTouchAPI::send() {
+	int ret = 0;
+
+	// Craft report(s)
+	_report.count = _fingers_count;
+
+	int rptentry=0;
+	for (int i = 0; i < HID_MULTITOUCH_MAXFINGERS; i++) {
+		if (_fingers[i].status == _MT_STATE_INACTIVE)
+			continue;
+
+		_report.contacts[rptentry].identifier = i; // valid for first report only
+
+		if (_fingers[i].status == _MT_STATE_RELEASED) {
+			// Released contacts need to be reported once with TipSW=0
+			_report.contacts[rptentry].touch = {};
+			_fingers_count--;
+			_fingers[i].status = _MT_STATE_INACTIVE;
+		} else {
+			// Active contacts must be reported even when not moved
+			_report.contacts[rptentry].touch = _fingers[i].pressure > 0 ? 3 : 1;
+			_report.contacts[rptentry].x1 = _MSB(_fingers[i].x);
+			_report.contacts[rptentry].x0 = _LSB(_fingers[i].x);
+			_report.contacts[rptentry].y1 = _MSB(_fingers[i].y);
+			_report.contacts[rptentry].y0 = _LSB(_fingers[i].y);
+			_report.contacts[rptentry].pressure = _fingers[i].pressure;
+		}
+
+		rptentry++;
+		if (rptentry == HID_MULTITOUCH_REPORTFINGERS) {
+			// Report full. Send now.
+			// If there are more contacts, they will be sent in subsequent
+			// reports with contact count set to 0
+			// See "Hybrid Mode" on MSDN docs
+			ret += _sendReport();
+			rptentry = 0;
+			_report.count = 0;
+		}
+	}
+
+	if (rptentry != 0) {
+		// Send remaining touches
+		for (; rptentry != HID_MULTITOUCH_REPORTFINGERS; rptentry++) {
+			_report.contacts[rptentry] = {};
+		}
+		ret += _sendReport();
+	}
+
+	return ret;
+}

--- a/src/SingleReport/MultiTouch.cpp
+++ b/src/SingleReport/MultiTouch.cpp
@@ -1,0 +1,246 @@
+/*
+Copyright (c) 2021 ilufang
+See the readme for credit to other people.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "MultiTouch.h"
+
+// HID Report identifiers
+#define _HID_REPORTID_TOUCH 0x01
+#define _HID_REPORTID_FEATURE 0x05
+
+// First part of the descriptor. It appears only once
+static const uint8_t _hidReportDescriptorTouchscreen_1[] PROGMEM = {
+	0x05, 0x0D,                    // USAGE_PAGE(Digitizers)
+	0x09, 0x04,                    // USAGE     (Touch Screen)
+	0xA1, 0x01,                    // COLLECTION(Application)
+
+	// define the actual amount of fingers that are concurrently touching the screen
+	0x85, _HID_REPORTID_TOUCH,     //   REPORT_ID (Touch)
+	0x09, 0x54,                    //   USAGE (Contact count)
+	0x25, 0x7f,                    //   LOGICAL_MAXIMUM (128)
+	0x95, 0x01,                    //   REPORT_COUNT(1)
+	0x75, 0x08,                    //   REPORT_SIZE (8)
+	0x81, 0x02                     //   INPUT (Data,Var,Abs)
+};
+
+// Finger definition part of the descriptor. It will repeat REPORTFINGERS times, once for each finger.
+// If more actual fingers are present than descriptor fingers, multiple reports will be sent sequentially under "Hybrid Mode" rule (See MSDN)
+static const uint8_t _hidReportDescriptorTouchscreen_2[] PROGMEM = {
+	// declare a finger collection
+	0x05, 0x0D,                    //   USAGE_PAGE(Digitizers)
+	0x09, 0x22,                    //   USAGE (Finger)
+	0xA1, 0x02,                    //   COLLECTION (Logical)
+
+	// declare an identifier for the finger
+	0x09, 0x51,                    //     USAGE (Contact Identifier)
+	0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+	0x75, 0x08,                    //     REPORT_SIZE (8)
+	0x95, 0x01,                    //     REPORT_COUNT (1)
+	0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+
+	// declare Tip Switch & In range
+	0x09, 0x42,                    //     USAGE (Tip Switch)
+	0x09, 0x32,                    //     USAGE (In Range)
+	0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
+	0x25, 0x01,                    //     LOGICAL_MAXIMUM (1)
+	0x75, 0x01,                    //     REPORT_SIZE (1)
+	0x95, 0x02,                    //     REPORT_COUNT(2)
+	0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+	// declare the 6 padding bits as constant so the driver will ignore them
+	0x95, 0x06,                    //     REPORT_COUNT (6)
+	0x81, 0x03,                    //     INPUT (Cnst,Ary,Abs)
+
+	// declare pressure
+	0x09, 0x30,                    //     USAGE (Pressure)
+	0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+	0x75, 0x08,                    //     REPORT_SIZE (8)
+	0x95, 0x01,                    //     REPORT_COUNT (1)
+	0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+
+	// define absolute X and Y coordinates of 16 bit each (percent values multiplied with 100)
+	0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
+	0x09, 0x30,                    //     Usage (X)
+	0x09, 0x31,                    //     Usage (Y)
+	0x16, 0x00, 0x00,              //     Logical Minimum (0)
+	0x26, 0x10, 0x27,              //     Logical Maximum (10000)
+	0x36, 0x00, 0x00,              //     Physical Minimum (0)
+	0x46, 0x10, 0x27,              //     Physical Maximum (10000)
+	0x66, 0x00, 0x00,              //     UNIT (None)
+	0x75, 0x10,                    //     Report Size (16),
+	0x95, 0x02,                    //     Report Count (2),
+	0x81, 0x02,                    //     Input (Data,Var,Abs)
+	0xC0                           //   END_COLLECTION
+};
+
+// Last of the descriptor. It appears only once
+static const uint8_t _hidReportDescriptorTouchscreen_3[] PROGMEM = {
+	// define the maximum amount of fingers that the device supports
+	0x05, 0x0D,                    //   USAGE_PAGE(Digitizers)
+	0x85, _HID_REPORTID_FEATURE,   //   REPORT_ID (Feature)
+	0x09, 0x55,                    //   USAGE (Contact Count Maximum)
+	0x25, 0x7f,                    //   LOGICAL_MAXIMUM (127)
+	0xB1, 0x02,                    //   FEATURE (Data,Var,Abs)
+
+	0xC0                           // END_COLLECTION
+};
+
+
+MultiTouch_::MultiTouch_(void) : PluggableUSBModule(2, 1, epType), protocol(HID_REPORT_PROTOCOL), idle(1), featureReport((uint8_t *)&_ccmFeature), featureLength(sizeof(_ccmFeature))
+{
+	_report.reportID = _HID_REPORTID_TOUCH;
+	_ccmFeature.reportID = _HID_REPORTID_FEATURE;
+	_ccmFeature.contactCountMaximum = HID_MULTITOUCH_MAXFINGERS;
+	epType[0] = EP_TYPE_INTERRUPT_IN;
+	PluggableUSB().plug(this);
+}
+
+int MultiTouch_::getInterface(uint8_t* interfaceCount)
+{
+	*interfaceCount += 1; // uses 1
+	HIDDescriptor hidInterface = {
+		D_INTERFACE(pluggedInterface, 1, USB_DEVICE_CLASS_HUMAN_INTERFACE, HID_SUBCLASS_NONE, HID_PROTOCOL_NONE),
+		D_HIDREPORT(sizeof(_hidReportDescriptorTouchscreen_1) + sizeof(_hidReportDescriptorTouchscreen_2) * HID_MULTITOUCH_REPORTFINGERS + sizeof(_hidReportDescriptorTouchscreen_3)),
+		D_ENDPOINT(USB_ENDPOINT_IN(pluggedEndpoint), USB_ENDPOINT_TYPE_INTERRUPT, USB_EP_SIZE, 0x01)
+	};
+	return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
+}
+
+int MultiTouch_::getDescriptor(USBSetup& setup)
+{
+	// Check if this is a HID Class Descriptor request
+	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
+	if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) { return 0; }
+
+	// In a HID Class Descriptor wIndex cointains the interface number
+	if (setup.wIndex != pluggedInterface) { return 0; }
+
+	// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+	// due to the USB specs, but Windows and Linux just assumes its in report mode.
+	protocol = HID_REPORT_PROTOCOL;
+
+	// Transmit HID descriptor. See comments next to the descriptor parts
+	int ret = 0;
+	ret += USB_SendControl(TRANSFER_PGM, _hidReportDescriptorTouchscreen_1, sizeof(_hidReportDescriptorTouchscreen_1));
+	for (int i = 0; i < HID_MULTITOUCH_REPORTFINGERS; i++) {
+		ret += USB_SendControl(TRANSFER_PGM, _hidReportDescriptorTouchscreen_2, sizeof(_hidReportDescriptorTouchscreen_2));
+	}
+	ret += USB_SendControl(TRANSFER_PGM, _hidReportDescriptorTouchscreen_3, sizeof(_hidReportDescriptorTouchscreen_3));
+
+	return ret;
+}
+
+bool MultiTouch_::setup(USBSetup& setup)
+{
+	if (pluggedInterface != setup.wIndex) {
+		return false;
+	}
+
+	uint8_t request = setup.bRequest;
+	uint8_t requestType = setup.bmRequestType;
+
+	if (requestType == REQUEST_DEVICETOHOST_CLASS_INTERFACE)
+	{
+		if (request == HID_GET_REPORT) {
+			if(setup.wValueH == HID_REPORT_TYPE_FEATURE){
+				// The only feature is Contact Count Maximum
+				USB_SendControl(0, featureReport, featureLength);
+				return true;
+			}
+			return true;
+		}
+		if (request == HID_GET_PROTOCOL) {
+			// TODO improve
+#ifdef __AVR__
+			UEDATX = protocol;
+#endif
+			return true;
+		}
+		if (request == HID_GET_IDLE) {
+			// TODO improve
+#ifdef __AVR__
+			UEDATX = idle;
+#endif
+			return true;
+		}
+	}
+
+	if (requestType == REQUEST_HOSTTODEVICE_CLASS_INTERFACE)
+	{
+		if (request == HID_SET_PROTOCOL) {
+			protocol = setup.wValueL;
+			return true;
+		}
+		if (request == HID_SET_IDLE) {
+			idle = setup.wValueL;
+			return true;
+		}
+		if (request == HID_SET_REPORT)
+		{
+			// Check if data has the correct length afterwards
+			int length = setup.wLength;
+
+			// Feature (set feature report)
+			if(setup.wValueH == HID_REPORT_TYPE_FEATURE){
+				// No need to check for negative featureLength values,
+				// except the host tries to send more then 32k bytes.
+				// We dont have that much ram anyways.
+				if (length == featureLength) {
+					USB_RecvControl(featureReport, featureLength);
+					return true;
+				}
+				// TODO fake clear data?
+			}
+
+			// Output (not applicable)
+			else if(setup.wValueH == HID_REPORT_TYPE_OUTPUT){
+				return true;
+			}
+
+			// Input (set HID report)
+			else if(setup.wValueH == HID_REPORT_TYPE_INPUT)
+			{
+				if(length == sizeof(_report)){
+					USB_RecvControl(&_report, length);
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+uint8_t MultiTouch_::getProtocol() {
+	return protocol;
+}
+
+int MultiTouch_::_sendReport() {
+	return USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_report, sizeof(_report));
+}
+
+void MultiTouch_::wakeupHost() {
+#ifdef __AVR__
+	USBDevice.wakeupHost();
+#endif
+}
+
+MultiTouch_ MultiTouch;

--- a/src/SingleReport/MultiTouch.h
+++ b/src/SingleReport/MultiTouch.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2014-2021 NicoHood
+Copyright (c) 2021 ilufang
 See the readme for credit to other people.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,34 +24,39 @@ THE SOFTWARE.
 // Include guard
 #pragma once
 
-// Software version
-#define HID_PROJECT_VERSION 280
+#include <Arduino.h>
+#include "HID.h"
+#include "HID-Settings.h"
+#include "../HID-APIs/MultiTouchAPI.h"
 
-#if ARDUINO < 10607
-#error HID Project requires Arduino IDE 1.6.7 or greater. Please update your IDE.
-#endif
 
-#if !defined(USBCON)
-#error HID Project can only be used with an USB MCU.
-#endif
+class MultiTouch_ : public PluggableUSBModule, public MultiTouchAPI
+{
+public:
+	MultiTouch_();
+	uint8_t getProtocol();
+	void wakeupHost();
 
-// Include all HID libraries (.a linkage required to work) properly
-#include "SingleReport/SingleAbsoluteMouse.h"
-#include "MultiReport/AbsoluteMouse.h"
-#include "SingleReport/BootMouse.h"
-#include "MultiReport/ImprovedMouse.h"
-#include "SingleReport/SingleConsumer.h"
-#include "MultiReport/Consumer.h"
-#include "SingleReport/SingleGamepad.h"
-#include "MultiReport/Gamepad.h"
-#include "SingleReport/SingleSystem.h"
-#include "MultiReport/System.h"
-#include "SingleReport/RawHID.h"
-#include "SingleReport/BootKeyboard.h"
-#include "MultiReport/ImprovedKeyboard.h"
-#include "SingleReport/SingleNKROKeyboard.h"
-#include "MultiReport/NKROKeyboard.h"
-#include "MultiReport/SurfaceDial.h"
-#include "SingleReport/MultiTouch.h"
+protected:
+	virtual int _sendReport() final;
 
-// Include Teensy HID afterwards to overwrite key definitions if used
+	// Implementation of the PUSBListNode
+	int getInterface(uint8_t* interfaceCount);
+	int getDescriptor(USBSetup& setup);
+	bool setup(USBSetup& setup);
+
+	EPTYPE_DESCRIPTOR_SIZE epType[1];
+	uint8_t protocol;
+	uint8_t idle;
+
+	uint8_t* featureReport;
+	int featureLength;
+
+private:
+	struct {
+		uint8_t reportID;
+		uint8_t contactCountMaximum;
+	} _ccmFeature;
+};
+
+extern MultiTouch_ MultiTouch;


### PR DESCRIPTION
Hi, I was trying to implement an Arduino project that would be recognized as a multi-touch screen by Windows when I saw #123 . After messing around with information from there and a whole bunch of random places on the Internet, I am able to get it work on my PC by adding a new device under the frameworks of this library. Here's my code that does it and I hope you find it useful.

A few implementation notes not already mentioned in the comments:

- An abstract touchscreen has more parameters than something like a mouse/keyboard, notably max number of concurrent touches, but given the way these classes are instantiated and linked, I cannot figure out a simple way to let the user configure the parameters. It seems to me that user would inevitably have to edit library code, so for now I just placed two defines in MultiTouchAPI.h.
- For the Windows case, MSDN specifies that an HID Feature to provide "Maximum Contact Count" is mandatory, and it seems that without it Windows would assume the device as single-touch and ignore or give weird reactions when more than one touches is reported. So to implement HID Feature, I have to use the single report format and do USB stuff to respond feature requests. For single-touch digitizer the feature isn't necessary so a multi-report format may be used, but I didn't spare the effort to do it.
- The current descriptor reports 2 touches at a time, up to a total of 10 touches. It is identified in system properties as 10-point touchscreen. Each touch has coordinates, pressure, in-range flag. There are a few other optional usages that may also be included in the descriptor.

This is the first time I tried to work with USB, so please correct me if my understanding, code or anything is incorrect.