### PR TITLE
Improved compatibility with Mac

### DIFF
--- a/src/SingleReport/BootMouse.cpp
+++ b/src/SingleReport/BootMouse.cpp
@@ -29,6 +29,10 @@ static const uint8_t _hidReportDescriptorMouse[] PROGMEM = {
     0x09, 0x02,                      /* USAGE (Mouse) */
     0xa1, 0x01,                      /* COLLECTION (Application) */
 
+    /* Pointer and Physical are required by Apple Recovery */
+    0x09, 0x01,                      /*   USAGE (Pointer) */
+    0xa1, 0x00,                      /*   COLLECTION (Physical) */
+
 	/* 8 Buttons */
     0x05, 0x09,                      /*     USAGE_PAGE (Button) */
     0x19, 0x01,                      /*     USAGE_MINIMUM (Button 1) */
@@ -51,6 +55,7 @@ static const uint8_t _hidReportDescriptorMouse[] PROGMEM = {
     0x81, 0x06,                      /*     INPUT (Data,Var,Rel) */
 
 	/* End */
+    0xc0,                           /* END_COLLECTION (Physical) */
     0xc0                            /* END_COLLECTION */
 };
 
@@ -73,18 +78,24 @@ int BootMouse_::getInterface(uint8_t* interfaceCount)
 
 int BootMouse_::getDescriptor(USBSetup& setup)
 {
-	// Check if this is a HID Class Descriptor request
-	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
-	if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) { return 0; }
-
 	// In a HID Class Descriptor wIndex cointains the interface number
 	if (setup.wIndex != pluggedInterface) { return 0; }
 
-	// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-	// due to the USB specs, but Windows and Linux just assumes its in report mode.
-	protocol = HID_REPORT_PROTOCOL;
+	// Check if this is a HID Class Descriptor request
+	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
 
-	return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorMouse, sizeof(_hidReportDescriptorMouse));
+	if (setup.wValueH == HID_HID_DESCRIPTOR_TYPE) {
+		// Apple UEFI wants it
+		HIDDescDescriptor desc = D_HIDREPORT(sizeof(_hidReportDescriptorMouse));
+		return USB_SendControl(0, &desc, sizeof(desc));
+	} else if (setup.wValueH == HID_REPORT_DESCRIPTOR_TYPE) {
+		// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+		// due to the USB specs, but Windows and Linux just assumes its in report mode.
+		protocol = HID_REPORT_PROTOCOL;
+		return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorMouse, sizeof(_hidReportDescriptorMouse));
+	}
+
+	return 0;
 }
 
 bool BootMouse_::setup(USBSetup& setup)
@@ -103,7 +114,17 @@ bool BootMouse_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_GET_PROTOCOL) {
-			// TODO: Send8(protocol);
+			// TODO improve
+#ifdef __AVR__
+			UEDATX = protocol;
+#endif
+			return true;
+		}
+		if (request == HID_GET_IDLE) {
+			// TODO improve
+#ifdef __AVR__
+			UEDATX = idle;
+#endif
 			return true;
 		}
 	}

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -29,6 +29,10 @@ static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
     0x09, 0x02,                      /* USAGE (Mouse) */
     0xA1, 0x01,                      /* COLLECTION (Application) */
 
+    /* Pointer and Physical are required by Apple Recovery */
+    0x09, 0x01,                      /*   USAGE (Pointer) */
+    0xa1, 0x00,                      /*   COLLECTION (Physical) */
+
 	/* 8 Buttons */
     0x05, 0x09,                      /*     USAGE_PAGE (Button) */
     0x19, 0x01,                      /*     USAGE_MINIMUM (Button 1) */
@@ -58,6 +62,7 @@ static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
     0x81, 0x06,                      /*     INPUT (Data,Var,Rel) */
 
 	/* End */
+    0xc0,                           /* END_COLLECTION (Physical) */
     0xc0                            /* END_COLLECTION */ 
 };
 


### PR DESCRIPTION
Using HID-Project on Mac was associated with two very big problems. This patch solves both - for the boot mouse and the absolute mouse. I believe these fixes could be relevant for other devices, but I have only dealt with these two.

1. When using any HID-Project mouse in Recovery Mode, Mac does can see it at the kernel level (that is, the cursor moves), but at the same time it asks connecting the mouse (which is already connected). The fact is that checking for the connected mouse is performed in a very stupid way: by searching for `USAGE(Pointer)` in the descriptors. Hardware mouse always (or almost always) have this, so adding this to the descriptor solves the problem. Details [here](https://github.com/pikvm/pikvm/issues/289) and [here](https://community.twocanoes.com/t/mds-automaton-keyboard-mouse-bluetooth-screen-in-macos-11-3/6391/3). I added this for absolute and boot mouses and it generally improves compatibility. It probably makes sense to do this for all mouses.

2. Another problem is that Apple UEFI (it uses another driver) could not work with BootMouse at all because it did not see it. It turned out that he needed a response to the `HID_HID_DESCRIPTOR_TYPE` request (which is strange, since we are already passing this descriptor in the interface). This is really part of the HID standard, and hardware mouse respond to this. Usually the BIOS and other things do not require this, but Apple UEFI turned out to be finicky.

I also added a bit of protocol and idle processing. It is better to let it be than not to be.

This patch is the result of my work with the hardware USB protocol analyzer. To understand the subtleties of Apple drivers, I compared how the Arduino behaves and how a "live" mouse works. All this is tested, of course.