### PR TITLE
Windows 7 can't handle negative absolute values

### DIFF
--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -78,8 +78,8 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
 	yAxis = y;
 	HID_MouseAbsoluteReport_Data_t report;
 	report.buttons = _buttons;
-	report.xAxis = x;
-	report.yAxis = y;
+	report.xAxis = ((long)x + 32768) / 2;
+	report.yAxis = ((long)y + 32768) / 2;
 	report.wheel = wheel;
 	SendReport(&report, sizeof(report));
 }

--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -80,7 +80,7 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
 	report.buttons = _buttons;
 	// The range -32768...32767 is converted to 0...32767 because Windows 7
 	// does not support negative coordinates.
-	// Negative values are supported here for compatibility reasons.
+	// Negative values are supported here for API compatibility reasons to keep (0,0) as a center of screen.
 	// See detauls in AbsoluteMouse sources and here: https://github.com/NicoHood/HID/pull/306
 	report.xAxis = ((int32_t)x + 32768) / 2;
 	report.yAxis = ((int32_t)y + 32768) / 2;

--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -80,6 +80,7 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
 	report.buttons = _buttons;
 	// The range -32768...32767 is converted to 0...32767 because Windows 7
 	// does not support negative coordinates.
+	// Negative values are supported here for compatibility reasons.
 	// See detauls in AbsoluteMouse sources and here: https://github.com/NicoHood/HID/pull/306
 	report.xAxis = ((int32_t)x + 32768) / 2;
 	report.yAxis = ((int32_t)y + 32768) / 2;

--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -78,8 +78,11 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
 	yAxis = y;
 	HID_MouseAbsoluteReport_Data_t report;
 	report.buttons = _buttons;
-	report.xAxis = ((long)x + 32768) / 2;
-	report.yAxis = ((long)y + 32768) / 2;
+	// The range -32768...32767 is converted to 0...32767 because Windows 7
+	// does not support negative coordinates.
+	// See detauls in AbsoluteMouse sources and here: https://github.com/NicoHood/HID/pull/306
+	report.xAxis = ((int32_t)x + 32768) / 2;
+	report.yAxis = ((int32_t)y + 32768) / 2;
 	report.wheel = wheel;
 	SendReport(&report, sizeof(report));
 }

--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -45,7 +45,7 @@ static const uint8_t _hidMultiReportDescriptorAbsoluteMouse[] PROGMEM = {
     0x05, 0x01,                      /*     USAGE_PAGE (Generic Desktop) */
     0x09, 0x30,                      /*     USAGE (X) */
     0x09, 0x31,                      /*     USAGE (Y) */
-	0x16, 0x00, 0x80,				 /* 	Logical Minimum (-32768) */
+	0x16, 0x00, 0x00,				 /* 	Logical Minimum (0); NOTE: Windows 7 can't handle negative value */
 	0x26, 0xFF, 0x7F,				 /* 	Logical Maximum (32767) */
 	0x75, 0x10,						 /* 	Report Size (16), */
 	0x95, 0x02,						 /* 	Report Count (2), */

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -47,7 +47,7 @@ static const uint8_t _hidSingleReportDescriptorAbsoluteMouse[] PROGMEM = {
     0x05, 0x01,                      /*     USAGE_PAGE (Generic Desktop) */
     0x09, 0x30,                      /*     USAGE (X) */
     0x09, 0x31,                      /*     USAGE (Y) */
-	0x16, 0x00, 0x80,				 /* 	Logical Minimum (-32768) */
+	0x16, 0x00, 0x00,				 /* 	Logical Minimum (0); NOTE: Windows 7 can't handle negative value */
 	0x26, 0xFF, 0x7F,				 /* 	Logical Maximum (32767) */
 	0x75, 0x10,						 /* 	Report Size (16), */
 	0x95, 0x02,						 /* 	Report Count (2), */


### PR DESCRIPTION
Just subj. When using negative values, only a quarter of the screen is available. All other OS and BIOSes work fine, but Windows 7 has a broken driver. The solution is taken from a drawing tablet - counting from zero. In addition, I have made sure that your API is backward compatible so that people can still use negative values.

In theory, this patch reduces the positioning accuracy, but 64K Super-Mega-Full-HD screens are unlikely to appear in the next 10 years for this to become a problem. Counting from zero works fine for all devices I know.