### PR TITLE
Bugfix: SET_IDLE uses wValueH for duration, not wValueL

### DIFF
--- a/src/SingleReport/BootKeyboard.cpp
+++ b/src/SingleReport/BootKeyboard.cpp
@@ -142,7 +142,7 @@ bool BootKeyboard_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/BootMouse.cpp
+++ b/src/SingleReport/BootMouse.cpp
@@ -136,7 +136,7 @@ bool BootMouse_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/RawHID.cpp
+++ b/src/SingleReport/RawHID.cpp
@@ -109,7 +109,7 @@ bool RawHID_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -128,7 +128,7 @@ bool SingleAbsoluteMouse_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/SingleConsumer.cpp
+++ b/src/SingleReport/SingleConsumer.cpp
@@ -100,7 +100,7 @@ bool SingleConsumer_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/SingleGamepad.cpp
+++ b/src/SingleReport/SingleGamepad.cpp
@@ -131,7 +131,7 @@ bool SingleGamepad_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/SingleNKROKeyboard.cpp
+++ b/src/SingleReport/SingleNKROKeyboard.cpp
@@ -131,7 +131,7 @@ bool SingleNKROKeyboard_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)

--- a/src/SingleReport/SingleSystem.cpp
+++ b/src/SingleReport/SingleSystem.cpp
@@ -102,7 +102,7 @@ bool SingleSystem_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)


### PR DESCRIPTION
Hello again :)

I found out that the duration in the SET_IDLE request is actually responsible for the highest byte, not the lowest. Here is an excerpt from the standard:
![image](https://user-images.githubusercontent.com/416259/126736549-402f5cf4-aa25-4b6c-b3b9-c6342ba6ea33.png)

![image](https://user-images.githubusercontent.com/416259/126736602-495becdf-d66e-4d8d-a52a-9537a308451a.png)

To verify this, I used [USBCV](https://www.usb.org/document-library/usb3cvx64-tool), the official tool for testing compliance with USB standards. Without this patch, the "Idle Test" was a failure, everything works as it should with the patch.

PS: Soon I will bring you a whole pack of new fixes to comply with the HID standard.