### PR TITLE
BootKeyboard, SingleAbsoluteMouse: handle HID_HID_DESCRIPTOR_TYPE

### DIFF
--- a/src/SingleReport/BootMouse.cpp
+++ b/src/SingleReport/BootMouse.cpp
@@ -85,7 +85,7 @@ int BootMouse_::getDescriptor(USBSetup& setup)
 	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
 
 	if (setup.wValueH == HID_HID_DESCRIPTOR_TYPE) {
-		// Apple UEFI wants it
+		// Apple UEFI and USBCV wants it
 		HIDDescDescriptor desc = D_HIDREPORT(sizeof(_hidReportDescriptorMouse));
 		return USB_SendControl(0, &desc, sizeof(desc));
 	} else if (setup.wValueH == HID_REPORT_DESCRIPTOR_TYPE) {

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -86,18 +86,24 @@ int SingleAbsoluteMouse_::getInterface(uint8_t* interfaceCount)
 
 int SingleAbsoluteMouse_::getDescriptor(USBSetup& setup)
 {
-	// Check if this is a HID Class Descriptor request
-	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
-	if (setup.wValueH != HID_REPORT_DESCRIPTOR_TYPE) { return 0; }
-
 	// In a HID Class Descriptor wIndex cointains the interface number
 	if (setup.wIndex != pluggedInterface) { return 0; }
 
-	// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
-	// due to the USB specs, but Windows and Linux just assumes its in report mode.
-	protocol = HID_REPORT_PROTOCOL;
+	// Check if this is a HID Class Descriptor request
+	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) { return 0; }
 
-	return USB_SendControl(TRANSFER_PGM, _hidSingleReportDescriptorAbsoluteMouse, sizeof(_hidSingleReportDescriptorAbsoluteMouse));
+	if (setup.wValueH == HID_HID_DESCRIPTOR_TYPE) {
+		// Apple UEFI and USBCV wants it
+		HIDDescDescriptor desc = D_HIDREPORT(sizeof(_hidSingleReportDescriptorAbsoluteMouse));
+		return USB_SendControl(0, &desc, sizeof(desc));
+	} else if (setup.wValueH == HID_REPORT_DESCRIPTOR_TYPE) {
+		// Reset the protocol on reenumeration. Normally the host should not assume the state of the protocol
+		// due to the USB specs, but Windows and Linux just assumes its in report mode.
+		protocol = HID_REPORT_PROTOCOL;
+		return USB_SendControl(TRANSFER_PGM, _hidSingleReportDescriptorAbsoluteMouse, sizeof(_hidSingleReportDescriptorAbsoluteMouse));
+	}
+
+	return 0;
 }
 
 bool SingleAbsoluteMouse_::setup(USBSetup& setup)


### PR DESCRIPTION
Continuation of the story in #305.

Handling of `HID_HID_DESCRIPTOR_TYPE` is required by [USBCV](https://www.usb.org/document-library/usb3cvx64-tool) (the official USB tool for testing for compliance with the standard).

So yes, this is the answer to your question: it looks like processing this is required for all HID devices. I added for those two devices that I had the opportunity to test.