### PR TITLE
Allow reducing gamepad buttons to 16 and removing Z-Axis easily

### DIFF
--- a/src/HID-APIs/GamepadAPI.h
+++ b/src/HID-APIs/GamepadAPI.h
@@ -38,13 +38,18 @@ THE SOFTWARE.
 #define GAMEPAD_DPAD_LEFT 7
 #define GAMEPAD_DPAD_UP_LEFT 8
 
+#ifdef HID_ENABLE_32BUTTONS
+typedef uint32_t HID_Buttons_t;
+#else
+typedef uint16_t HID_Buttons_t;
+#endif
 
 typedef union ATTRIBUTE_PACKED {
 	// 32 Buttons, 6 Axis, 2 D-Pads
 	uint8_t whole8[0];
 	uint16_t whole16[0];
 	uint32_t whole32[0];
-	uint32_t buttons;
+	HID_Buttons_t buttons;
 
 	struct ATTRIBUTE_PACKED {
 		uint8_t button1 : 1;
@@ -65,6 +70,7 @@ typedef union ATTRIBUTE_PACKED {
 		uint8_t button15 : 1;
 		uint8_t button16 : 1;
 
+#ifdef HID_ENABLE_32BUTTONS
 		uint8_t button17 : 1;
 		uint8_t button18 : 1;
 		uint8_t button19 : 1;
@@ -82,6 +88,7 @@ typedef union ATTRIBUTE_PACKED {
 		uint8_t button30 : 1;
 		uint8_t button31 : 1;
 		uint8_t button32 : 1;
+#endif
 
 		int16_t	xAxis;
 		int16_t	yAxis;
@@ -89,9 +96,10 @@ typedef union ATTRIBUTE_PACKED {
 		int16_t	rxAxis;
 		int16_t	ryAxis;
 
+#ifdef HID_ENABLE_ZAXIS
 		int8_t	zAxis;
 		int8_t	rzAxis;
-
+#endif
 		uint8_t	dPad1 : 4;
 		uint8_t	dPad2 : 4;
 	};
@@ -108,13 +116,17 @@ public:
 	inline void release(uint8_t b);
 	inline void releaseAll(void);
 
-	inline void buttons(uint32_t b);
+	inline void buttons(HID_Buttons_t b);
 	inline void xAxis(int16_t a);
 	inline void yAxis(int16_t a);
+#ifdef HID_ENABLE_ZAXIS
 	inline void zAxis(int8_t a);
+#endif
 	inline void rxAxis(int16_t a);
 	inline void ryAxis(int16_t a);
+#ifdef HID_ENABLE_ZAXIS
 	inline void rzAxis(int8_t a);
+#endif
 	inline void dPad1(int8_t d);
 	inline void dPad2(int8_t d);
 

--- a/src/HID-APIs/GamepadAPI.hpp
+++ b/src/HID-APIs/GamepadAPI.hpp
@@ -45,12 +45,12 @@ void GamepadAPI::write(void){
 
 
 void GamepadAPI::press(uint8_t b){ 
-	_report.buttons |= (uint32_t)1 << (b - 1); 
+	_report.buttons |= (HID_Buttons_t)1 << (b - 1); 
 }
 
 
 void GamepadAPI::release(uint8_t b){ 
-	_report.buttons &= ~((uint32_t)1 << (b - 1)); 
+	_report.buttons &= ~((HID_Buttons_t)1 << (b - 1)); 
 }
 
 
@@ -58,7 +58,7 @@ void GamepadAPI::releaseAll(void){
 	memset(&_report, 0x00, sizeof(_report)); 
 }
 
-void GamepadAPI::buttons(uint32_t b){ 
+void GamepadAPI::buttons(HID_Buttons_t b){ 
 	_report.buttons = b; 
 }
 
@@ -72,11 +72,11 @@ void GamepadAPI::yAxis(int16_t a){
 	_report.yAxis = a; 
 }
 
-
+#ifdef HID_ENABLE_ZAXIS
 void GamepadAPI::zAxis(int8_t a){ 
 	_report.zAxis = a; 
 }
-
+#endif
 
 void GamepadAPI::rxAxis(int16_t a){ 
 	_report.rxAxis = a; 
@@ -87,11 +87,11 @@ void GamepadAPI::ryAxis(int16_t a){
 	_report.ryAxis = a; 
 }
 
-
+#ifdef HID_ENABLE_ZAXIS
 void GamepadAPI::rzAxis(int8_t a){ 
 	_report.rzAxis = a; 
 }
-
+#endif
 
 void GamepadAPI::dPad1(int8_t d){ 
 	_report.dPad1 = d; 

--- a/src/HID-Settings.h
+++ b/src/HID-Settings.h
@@ -28,6 +28,11 @@ THE SOFTWARE.
 // Settings
 //================================================================================
 
+// Undefine this if 16 buttons are enough for your Gamepads
+#define HID_ENABLE_32BUTTONS
+
+// Undefine this is your Gamepads don't need a Z Axis
+#define HID_ENABLE_ZAXIS
 
 #define HID_REPORTID_NONE 0
 

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -25,19 +25,27 @@ THE SOFTWARE.
 
 
 static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
-	/* Gamepad with 32 buttons and 6 axis*/
+	/* Gamepad with 16/32 buttons and 6 axis*/
 	0x05, 0x01,							/* USAGE_PAGE (Generic Desktop) */
 	0x09, 0x04,							/* USAGE (Joystick) */
 	0xa1, 0x01,							/* COLLECTION (Application) */
 	0x85, HID_REPORTID_GAMEPAD,			/*   REPORT_ID */
-	/* 32 Buttons */
+	/* 16/32 Buttons */
 	0x05, 0x09,							/*   USAGE_PAGE (Button) */
 	0x19, 0x01,							/*   USAGE_MINIMUM (Button 1) */
+#ifdef HID_ENABLE_32BUTTONS
 	0x29, 0x20,							/*   USAGE_MAXIMUM (Button 32) */
+#else
+	0x29, 0x10,							/*   USAGE_MAXIMUM (Button 16) */
+#endif
 	0x15, 0x00,							/*   LOGICAL_MINIMUM (0) */
 	0x25, 0x01,							/*   LOGICAL_MAXIMUM (1) */
 	0x75, 0x01,							/*   REPORT_SIZE (1) */
+#ifdef HID_ENABLE_32BUTTONS
 	0x95, 0x20,							/*   REPORT_COUNT (32) */
+#else
+	0x95, 0x10,							/*   REPORT_COUNT (16) */
+#endif
 	0x81, 0x02,							/*   INPUT (Data,Var,Abs) */
 	/* 4 16bit Axis */
 	0x05, 0x01,							/*   USAGE_PAGE (Generic Desktop) */
@@ -51,6 +59,7 @@ static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
 	0x75, 0x10,							/*     REPORT_SIZE (16) */
 	0x95, 0x04,							/*     REPORT_COUNT (4) */
 	0x81, 0x02,							/*     INPUT (Data,Var,Abs) */
+#ifdef HID_ENABLE_ZAXIS
 	/* 2 8bit Axis */
 	0x09, 0x32,							/*     USAGE (Z) */
 	0x09, 0x35,							/*     USAGE (Rz) */
@@ -59,6 +68,7 @@ static const uint8_t _hidMultiReportDescriptorGamepad[] PROGMEM = {
 	0x75, 0x08,							/*     REPORT_SIZE (8) */
 	0x95, 0x02,							/*     REPORT_COUNT (2) */
 	0x81, 0x02,							/*     INPUT (Data,Var,Abs) */
+#endif
 	0xc0,								/*   END_COLLECTION */
 	/* 2 Hat Switches */
 	0x05, 0x01,							/*   USAGE_PAGE (Generic Desktop) */

--- a/src/SingleReport/SingleGamepad.cpp
+++ b/src/SingleReport/SingleGamepad.cpp
@@ -24,18 +24,26 @@ THE SOFTWARE.
 #include "SingleGamepad.h"
 
 static const uint8_t _hidReportDescriptorGamepad[] PROGMEM = {
-	/* Gamepad with 32 buttons and 6 axis*/
+	/* Gamepad with 16/32 buttons and 6 axis*/
 	0x05, 0x01,							/* USAGE_PAGE (Generic Desktop) */
 	0x09, 0x04,							/* USAGE (Joystick) */
 	0xa1, 0x01,							/* COLLECTION (Application) */
-	/* 32 Buttons */
+	/* 16/32 Buttons */
 	0x05, 0x09,							/*   USAGE_PAGE (Button) */
 	0x19, 0x01,							/*   USAGE_MINIMUM (Button 1) */
+#ifdef HID_ENABLE_32BUTTONS
 	0x29, 0x20,							/*   USAGE_MAXIMUM (Button 32) */
+#else
+	0x29, 0x10,							/*   USAGE_MAXIMUM (Button 16) */
+#endif
 	0x15, 0x00,							/*   LOGICAL_MINIMUM (0) */
 	0x25, 0x01,							/*   LOGICAL_MAXIMUM (1) */
 	0x75, 0x01,							/*   REPORT_SIZE (1) */
+#ifdef HID_ENABLE_32BUTTONS
 	0x95, 0x20,							/*   REPORT_COUNT (32) */
+#else
+	0x95, 0x10,							/*   REPORT_COUNT (32) */
+#endif
 	0x81, 0x02,							/*   INPUT (Data,Var,Abs) */
 	/* 4 16bit Axis */
 	0x05, 0x01,							/*   USAGE_PAGE (Generic Desktop) */
@@ -49,6 +57,7 @@ static const uint8_t _hidReportDescriptorGamepad[] PROGMEM = {
 	0x75, 0x10,							/*     REPORT_SIZE (16) */
 	0x95, 0x04,							/*     REPORT_COUNT (4) */
 	0x81, 0x02,							/*     INPUT (Data,Var,Abs) */
+#ifdef HID_ENABLE_ZAXIS
 	/* 2 8bit Axis */
 	0x09, 0x32,							/*     USAGE (Z) */
 	0x09, 0x35,							/*     USAGE (Rz) */
@@ -57,6 +66,7 @@ static const uint8_t _hidReportDescriptorGamepad[] PROGMEM = {
 	0x75, 0x08,							/*     REPORT_SIZE (8) */
 	0x95, 0x02,							/*     REPORT_COUNT (2) */
 	0x81, 0x02,							/*     INPUT (Data,Var,Abs) */
+#endif
 	0xc0,								/*   END_COLLECTION */
 	/* 2 Hat Switches */
 	0x05, 0x01,							/*   USAGE_PAGE (Generic Desktop) */


### PR DESCRIPTION
This patch does nothing by default, but adds a few configuration options for the above into HID-Settings.h.