### PR TITLE
fix missing return in function requiring return value!

### DIFF
--- a/src/port/samd.cpp
+++ b/src/port/samd.cpp
@@ -4,11 +4,11 @@
 
 #if !defined(ARDUINO_API_VERSION)
 int USB_SendControl(void* b, unsigned char c) {
-    USBDevice.sendControl(b, c);
+    return USBDevice.sendControl(b, c);
 }
 
 int USB_SendControl(uint8_t a, const void* b, uint8_t c) {
-    USBDevice.sendControl(b, c);
+    return USBDevice.sendControl(b, c);
 }
 #endif
 


### PR DESCRIPTION
this was throwing a compilation error on our SAMD core (we require functions to return values if they say they will :) functionality should now be the same on any/all compilers