### PR TITLE
Add HID_DONT_CREATE_INSTANCES flag (workaround for #266 #316 #139)

### DIFF
--- a/src/MultiReport/AbsoluteMouse.cpp
+++ b/src/MultiReport/AbsoluteMouse.cpp
@@ -75,5 +75,6 @@ void AbsoluteMouse_::SendReport(void* data, int length)
 	HID().SendReport(HID_REPORTID_MOUSE_ABSOLUTE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 AbsoluteMouse_ AbsoluteMouse;
-
+#endif

--- a/src/MultiReport/AbsoluteMouse.h
+++ b/src/MultiReport/AbsoluteMouse.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern AbsoluteMouse_ AbsoluteMouse;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern AbsoluteMouse_ AbsoluteMouse;
+#endif

--- a/src/MultiReport/Consumer.cpp
+++ b/src/MultiReport/Consumer.cpp
@@ -53,5 +53,6 @@ void Consumer_::SendReport(void* data, int length)
 	HID().SendReport(HID_REPORTID_CONSUMERCONTROL, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 Consumer_ Consumer;
-
+#endif

--- a/src/MultiReport/Consumer.h
+++ b/src/MultiReport/Consumer.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern Consumer_ Consumer;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern Consumer_ Consumer;
+#endif

--- a/src/MultiReport/Gamepad.cpp
+++ b/src/MultiReport/Gamepad.cpp
@@ -84,5 +84,6 @@ void Gamepad_::SendReport(void* data, int length)
 	HID().SendReport(HID_REPORTID_GAMEPAD, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 Gamepad_ Gamepad;
-
+#endif

--- a/src/MultiReport/Gamepad.h
+++ b/src/MultiReport/Gamepad.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern Gamepad_ Gamepad;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern Gamepad_ Gamepad;
+#endif

--- a/src/MultiReport/ImprovedKeyboard.cpp
+++ b/src/MultiReport/ImprovedKeyboard.cpp
@@ -81,5 +81,6 @@ void Keyboard_::wakeupHost(void){
 #endif
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 Keyboard_ Keyboard;
-
+#endif

--- a/src/MultiReport/ImprovedKeyboard.h
+++ b/src/MultiReport/ImprovedKeyboard.h
@@ -38,5 +38,7 @@ public:
 
     virtual inline int send(void) final;
 };
-extern Keyboard_ Keyboard;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern Keyboard_ Keyboard;
+#endif

--- a/src/MultiReport/ImprovedMouse.cpp
+++ b/src/MultiReport/ImprovedMouse.cpp
@@ -69,5 +69,6 @@ void Mouse_::SendReport(void* data, int length)
 	HID().SendReport(HID_REPORTID_MOUSE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 Mouse_ Mouse;
-
+#endif

--- a/src/MultiReport/ImprovedMouse.h
+++ b/src/MultiReport/ImprovedMouse.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern Mouse_ Mouse;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern Mouse_ Mouse;
+#endif

--- a/src/MultiReport/NKROKeyboard.cpp
+++ b/src/MultiReport/NKROKeyboard.cpp
@@ -73,5 +73,6 @@ int NKROKeyboard_::send(void)
 	return HID().SendReport(HID_REPORTID_NKRO_KEYBOARD, &_keyReport, sizeof(_keyReport));
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 NKROKeyboard_ NKROKeyboard;
-
+#endif

--- a/src/MultiReport/NKROKeyboard.h
+++ b/src/MultiReport/NKROKeyboard.h
@@ -37,5 +37,7 @@ public:
 
     virtual int send(void) final;
 };
-extern NKROKeyboard_ NKROKeyboard;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern NKROKeyboard_ NKROKeyboard;
+#endif

--- a/src/MultiReport/SurfaceDial.cpp
+++ b/src/MultiReport/SurfaceDial.cpp
@@ -84,4 +84,6 @@ void SurfaceDial_::SendReport(void *data, int length)
     HID().SendReport(HID_REPORTID_SURFACEDIAL, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SurfaceDial_ SurfaceDial;
+#endif

--- a/src/MultiReport/SurfaceDial.h
+++ b/src/MultiReport/SurfaceDial.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern SurfaceDial_ SurfaceDial;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern SurfaceDial_ SurfaceDial;
+#endif

--- a/src/MultiReport/System.cpp
+++ b/src/MultiReport/System.cpp
@@ -54,5 +54,7 @@ void System_::SendReport(void* data, int length)
 	HID().SendReport(HID_REPORTID_SYSTEMCONTROL, data, length);
 }
 
-System_ System;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+System_ System;
+#endif

--- a/src/MultiReport/System.h
+++ b/src/MultiReport/System.h
@@ -38,5 +38,7 @@ public:
 protected: 
     virtual inline void SendReport(void* data, int length) override;
 };
-extern System_ System;
 
+#ifndef HID_DONT_CREATE_INSTANCES
+extern System_ System;
+#endif

--- a/src/SingleReport/BootKeyboard.cpp
+++ b/src/SingleReport/BootKeyboard.cpp
@@ -211,7 +211,6 @@ void BootKeyboard_::wakeupHost(void){
 #endif
 }
 
-
+#ifndef HID_DONT_CREATE_INSTANCES
 BootKeyboard_ BootKeyboard;
-
-
+#endif

--- a/src/SingleReport/BootKeyboard.h
+++ b/src/SingleReport/BootKeyboard.h
@@ -80,6 +80,7 @@ protected:
     uint8_t* featureReport;
     int featureLength;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern BootKeyboard_ BootKeyboard;
-
-
+#endif

--- a/src/SingleReport/BootMouse.cpp
+++ b/src/SingleReport/BootMouse.cpp
@@ -160,6 +160,6 @@ void BootMouse_::SendReport(void* data, int length){
 	}
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 BootMouse_ BootMouse;
-
-
+#endif

--- a/src/SingleReport/BootMouse.h
+++ b/src/SingleReport/BootMouse.h
@@ -48,6 +48,7 @@ protected:
     
     virtual void SendReport(void* data, int length) override;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern BootMouse_ BootMouse;
-
-
+#endif

--- a/src/SingleReport/RawHID.cpp
+++ b/src/SingleReport/RawHID.cpp
@@ -146,4 +146,6 @@ bool RawHID_::setup(USBSetup& setup)
 	return false;
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 RawHID_ RawHID;
+#endif

--- a/src/SingleReport/RawHID.h
+++ b/src/SingleReport/RawHID.h
@@ -175,4 +175,7 @@ protected:
 	uint8_t* featureReport;
 	int featureLength;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern RawHID_ RawHID;
+#endif

--- a/src/SingleReport/SingleAbsoluteMouse.cpp
+++ b/src/SingleReport/SingleAbsoluteMouse.cpp
@@ -150,6 +150,6 @@ void SingleAbsoluteMouse_::SendReport(void* data, int length)
 	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SingleAbsoluteMouse_ SingleAbsoluteMouse;
-
-
+#endif

--- a/src/SingleReport/SingleAbsoluteMouse.h
+++ b/src/SingleReport/SingleAbsoluteMouse.h
@@ -49,6 +49,7 @@ protected:
     
     virtual inline void SendReport(void* data, int length) override;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern SingleAbsoluteMouse_ SingleAbsoluteMouse;
-
-
+#endif

--- a/src/SingleReport/SingleConsumer.cpp
+++ b/src/SingleReport/SingleConsumer.cpp
@@ -116,6 +116,6 @@ void SingleConsumer_::SendReport(void* data, int length)
 	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SingleConsumer_ SingleConsumer;
-
-
+#endif

--- a/src/SingleReport/SingleConsumer.h
+++ b/src/SingleReport/SingleConsumer.h
@@ -49,6 +49,7 @@ protected:
     
     virtual inline void SendReport(void* data, int length) override;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern SingleConsumer_ SingleConsumer;
-
-
+#endif

--- a/src/SingleReport/SingleGamepad.cpp
+++ b/src/SingleReport/SingleGamepad.cpp
@@ -146,9 +146,9 @@ void SingleGamepad_::SendReport(void* data, int length){
 	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SingleGamepad_ Gamepad1;
 SingleGamepad_ Gamepad2;
 SingleGamepad_ Gamepad3;
 SingleGamepad_ Gamepad4;
-
-
+#endif

--- a/src/SingleReport/SingleGamepad.h
+++ b/src/SingleReport/SingleGamepad.h
@@ -47,9 +47,10 @@ protected:
     
     virtual void SendReport(void* data, int length) override;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern SingleGamepad_ Gamepad1;
 extern SingleGamepad_ Gamepad2;
 extern SingleGamepad_ Gamepad3;
 extern SingleGamepad_ Gamepad4;
-
-
+#endif

--- a/src/SingleReport/SingleNKROKeyboard.cpp
+++ b/src/SingleReport/SingleNKROKeyboard.cpp
@@ -155,6 +155,6 @@ int SingleNKROKeyboard_::send(void){
 	return USB_Send(pluggedEndpoint | TRANSFER_RELEASE, &_keyReport, sizeof(_keyReport));
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SingleNKROKeyboard_ SingleNKROKeyboard;
-
-
+#endif

--- a/src/SingleReport/SingleNKROKeyboard.h
+++ b/src/SingleReport/SingleNKROKeyboard.h
@@ -51,6 +51,7 @@ protected:
     
     uint8_t leds;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern SingleNKROKeyboard_ SingleNKROKeyboard;
-
-
+#endif

--- a/src/SingleReport/SingleSystem.cpp
+++ b/src/SingleReport/SingleSystem.cpp
@@ -118,6 +118,6 @@ void SingleSystem_::SendReport(void* data, int length)
 	USB_Send(pluggedEndpoint | TRANSFER_RELEASE, data, length);
 }
 
+#ifndef HID_DONT_CREATE_INSTANCES
 SingleSystem_ SingleSystem;
-
-
+#endif

--- a/src/SingleReport/SingleSystem.h
+++ b/src/SingleReport/SingleSystem.h
@@ -49,6 +49,7 @@ protected:
     
     virtual inline void SendReport(void* data, int length) override;
 };
+
+#ifndef HID_DONT_CREATE_INSTANCES
 extern SingleSystem_ SingleSystem;
-
-
+#endif


### PR DESCRIPTION
If `HID_DONT_CREATE_INSTANCES` is defined, no default instances will be created. This allows the user to have a better control of have the (usually limited) reports are used. 