### PR TITLE
Support AVR cores without UEDATX (e.g. AVR-DU via DxCore)

### DIFF
--- a/src/HID-Settings.h
+++ b/src/HID-Settings.h
@@ -82,6 +82,15 @@ THE SOFTWARE.
 
 #define EPTYPE_DESCRIPTOR_SIZE      uint8_t
 
+#elif defined(ARDUINO_ARCH_MEGAAVR)
+
+// Use default alignment for megaAVR (AVR-Dx/DU native USB via DxCore)
+#define ATTRIBUTE_PACKED
+
+#include "PluggableUSB.h"
+
+#define EPTYPE_DESCRIPTOR_SIZE      uint8_t
+
 #elif defined(ARDUINO_ARCH_SAM)
 
 #define ATTRIBUTE_PACKED  __attribute__((packed, aligned(1)))

--- a/src/SingleReport/BootKeyboard.cpp
+++ b/src/SingleReport/BootKeyboard.cpp
@@ -127,14 +127,14 @@ bool BootKeyboard_::setup(USBSetup& setup)
 		}
 		if (request == HID_GET_PROTOCOL) {
 			// TODO improve
-#ifdef __AVR__
+#if defined(UEDATX)
 			UEDATX = protocol;
 #endif
 			return true;
 		}
 		if (request == HID_GET_IDLE) {
 			// TODO improve
-#ifdef __AVR__
+#if defined(UEDATX)
 			UEDATX = idle;
 #endif
 			return true;

--- a/src/SingleReport/BootMouse.cpp
+++ b/src/SingleReport/BootMouse.cpp
@@ -115,14 +115,14 @@ bool BootMouse_::setup(USBSetup& setup)
 		}
 		if (request == HID_GET_PROTOCOL) {
 			// TODO improve
-#ifdef __AVR__
+#if defined(UEDATX)
 			UEDATX = protocol;
 #endif
 			return true;
 		}
 		if (request == HID_GET_IDLE) {
 			// TODO improve
-#ifdef __AVR__
+#if defined(UEDATX)
 			UEDATX = idle;
 #endif
 			return true;


### PR DESCRIPTION
## Summary

Adds support for AVR cores that have a native USB peripheral but **no
`UEDATX` register** — specifically the new AVR-DU series (e.g. AVR64DU32)
used via DxCore, which exposes USB through the Pluggable USB API on the
`megaavr` architecture.

## Changes

- **HID-Settings.h**: add an `ARDUINO_ARCH_MEGAAVR` branch alongside the
  existing AVR/SAM/SAMD branches. It uses default struct alignment,
  includes `PluggableUSB.h`, and sets `EPTYPE_DESCRIPTOR_SIZE` to
  `uint8_t`, matching how DxCore presents the DU USB device.
- **BootKeyboard.cpp / BootMouse.cpp**: change the LED/output report
  fallback guard from `#ifdef __AVR__` to `#if defined(UEDATX)`.

## Why the `UEDATX` guard

The boot keyboard/mouse code used `#ifdef __AVR__` to gate access to
`UEDATX` (the ATmega32U4-style USB data register). The AVR-DU series is
an AVR part but has a completely different USB peripheral and does **not**
define `UEDATX`, so `#ifdef __AVR__` was true and the code failed to
build. Guarding on `#if defined(UEDATX)` keeps the existing behavior on
32U4-class parts while letting non-UEDATX AVR parts fall through to the
PluggableUSB path. This is a general fix, not specific to AVR-DU.

## Testing

**Arduino Leonardo (ATmega32U4)** — verified no regression on the parts
this change touches: `BootKeyboard`, `BootMouse`, and `Gamepad` examples
build and work as before. Since 32U4 defines `UEDATX`, the
`#if defined(UEDATX)` guard evaluates the same as the previous
`#ifdef __AVR__`, with no observable behavior change.

**AVR64DU32 Curiosity Nano** (via DxCore, USB support in progress at
SpenceKonde/DxCore#637) — the following HID-Project examples build and
work on hardware: `BootKeyboard`, `ImprovedKeyboard`, `NKROKeyboard`,
`KeyboardLED` (host-to-device LED feedback), `AlternateLanguageLayout`,
`KeyLayoutTest`, `RawHID` (both directions), `Consumer`, `AbsoluteMouse`,
`ImprovedMouse`, `Gamepad`, `SurfaceDial`, `System`.